### PR TITLE
WindowManager 1.0.0 alpha02 update

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -18,7 +18,6 @@ allprojects {
     repositories {
         google()
         jcenter()
-        maven { url 'https://androidx.dev/snapshots/builds/7033903/artifacts/repository/' }
     }
 }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Thu Nov 19 14:23:45 CET 2020
+#Wed Jan 27 11:06:42 CET 2021
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.7.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.7.1-all.zip

--- a/window-manager/build.gradle
+++ b/window-manager/build.gradle
@@ -43,7 +43,7 @@ dependencies {
     implementation 'com.google.android.material:material:1.2.1'
     implementation 'androidx.constraintlayout:constraintlayout:2.0.4'
 
-    implementation "androidx.window:window:1.0.0-SNAPSHOT"
+    implementation "androidx.window:window:1.0.0-alpha02"
 
     testImplementation 'junit:junit:4.13.1'
     androidTestImplementation 'androidx.test.ext:junit:1.1.2'


### PR DESCRIPTION
This branch/PR updates the window-manager sample using now the already available Window Manager 1.0.0-alpha02  (https://developer.android.com/jetpack/androidx/releases/window#window-1.0.0-alpha02)